### PR TITLE
Additional fix dict updates

### DIFF
--- a/qiskit/providers/aer/pulse/system_models/duffing_model_generators.py
+++ b/qiskit/providers/aer/pulse/system_models/duffing_model_generators.py
@@ -124,7 +124,6 @@ def duffing_system_model(dim_oscillators,
     anharm_symbol = 'alpha'
     drive_symbol = 'r'
     coupling_symbol = 'j'
-
     coupling_edges = coupling_dict.keys()
 
     # construct coupling graph, and raise warning if coupling_edges contains duplicate edges
@@ -143,8 +142,13 @@ def duffing_system_model(dim_oscillators,
     sorted_coupling_edges = coupling_graph.sorted_graph
     # populate coupling strengths in sorted order (vertex indices are now also sorted within edges,
     # so this needs to be accounted for when retrieving weights from coupling_dict)
-    coupling_strengths = [coupling_dict.get(edge) or coupling_dict.get((edge[1], edge[0])) for
-                          edge in sorted_coupling_edges]
+    coupling_strengths = []
+    for edge in sorted_coupling_edges:
+        edge_strength = coupling_dict.get(edge)
+        if edge_strength is None:
+            edge_strength = coupling_dict.get((edge[1], edge[0]))
+        coupling_strengths.append(edge_strength)
+
     coupling_symbols = _str_list_generator(coupling_symbol + '{0}{1}', *zip(*sorted_coupling_edges))
     cr_idx_dict = coupling_graph.two_way_graph_dict
 

--- a/qiskit/providers/aer/pulse/system_models/duffing_model_generators.py
+++ b/qiskit/providers/aer/pulse/system_models/duffing_model_generators.py
@@ -17,9 +17,9 @@
 
 from warnings import warn
 from collections.abc import Iterable
+from qiskit.providers.models.backendconfiguration import UchannelLO
 from .hamiltonian_model import HamiltonianModel
 from .pulse_system_model import PulseSystemModel
-from qiskit.providers.models.backendconfiguration import UchannelLO
 
 
 def duffing_system_model(dim_oscillators,
@@ -274,7 +274,7 @@ def _cr_lo_list(cr_idx_dict):
     # populate list of u channel lo for cr gates
     lo_list = [0] * len(cr_idx_dict)
     for system_pair, u_idx in cr_idx_dict.items():
-        lo_list[u_idx] = [UchannelLO(system_pair[1], 1.0+0.0j)]
+        lo_list[u_idx] = [UchannelLO(system_pair[1], 1.0 + 0.0j)]
 
     return lo_list
 

--- a/qiskit/providers/aer/pulse/system_models/duffing_model_generators.py
+++ b/qiskit/providers/aer/pulse/system_models/duffing_model_generators.py
@@ -19,6 +19,7 @@ from warnings import warn
 from collections.abc import Iterable
 from .hamiltonian_model import HamiltonianModel
 from .pulse_system_model import PulseSystemModel
+from qiskit.providers.models.backendconfiguration import UchannelLO
 
 
 def duffing_system_model(dim_oscillators,
@@ -269,7 +270,7 @@ def _cr_lo_list(cr_idx_dict):
     # populate list of u channel lo for cr gates
     lo_list = [0] * len(cr_idx_dict)
     for system_pair, u_idx in cr_idx_dict.items():
-        lo_list[u_idx] = [{'scale': [1.0, 0.0], 'q': system_pair[1]}]
+        lo_list[u_idx] = [UchannelLO(system_pair[1], 1.0+0.0j)]
 
     return lo_list
 

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -928,13 +928,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         ham_model = HamiltonianModel.from_dict(hamiltonian, subsystem_list)
 
 
-        u_channel_lo = [[UchannelLO.from_dict({'q': 0, 'scale': [1.0, 0.0]})]]
-        u_channel_lo.append([UchannelLO.from_dict(x) for x in [
-                             {'q': 0, 'scale': -1.0+0.0j},
-                             {'q': 2, 'scale': 1.0+0.0j}]])
-        u_channel_lo.append([UchannelLO.from_dict(x) for x in [
-                            {'q': 1, 'scale': -1.0+0.0j},
-                            {'q': 2, 'scale': 1.0+0.0j}]])
+        u_channel_lo = [[UchannelLO(0, 1.0+0.0j)]]
+        u_channel_lo.append([UchannelLO(0, -1.0+0.0j), UchannelLO(2, 1.0+0.0j)])
+        u_channel_lo.append([UchannelLO(1, -1.0+0.0j), UchannelLO(2, 1.0+0.0j)])
         dt = 1.
 
         return PulseSystemModel(hamiltonian=ham_model,

--- a/test/terra/openpulse/test_duffing_model_generators.py
+++ b/test/terra/openpulse/test_duffing_model_generators.py
@@ -405,6 +405,28 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
         self.assertEqual(output['qub'], expected['qub'])
 
 
+    def test_calculate_channel_frequencies(self):
+        """test calculate_channel_frequencies of resulting PulseSystemModel objects"""
+
+        dim_oscillators = 2
+        oscillator_freqs = [5.0, 5.1]
+        anharm_freqs = [-0.33, -0.33]
+        drive_strengths = [1.1, 1.2]
+        coupling_dict = {(0,1): 0.0}
+        dt = 1.3
+
+        system_model = model_gen.duffing_system_model(dim_oscillators,
+                                                      oscillator_freqs,
+                                                      anharm_freqs,
+                                                      drive_strengths,
+                                                      coupling_dict,
+                                                      dt)
+
+        channel_freqs = system_model.calculate_channel_frequencies([5.0, 5.1])
+        expected = {'D0' : 5.0, 'D1' : 5.1, 'U0' : 5.1, 'U1': 5.0}
+        self.assertEqual(dict(channel_freqs), expected)
+
+
 
     def test_cr_lo_list(self):
         """Test _cr_lo_list"""

--- a/test/terra/openpulse/test_duffing_model_generators.py
+++ b/test/terra/openpulse/test_duffing_model_generators.py
@@ -20,6 +20,7 @@ from qiskit.providers.aer.pulse.system_models.pulse_system_model import PulseSys
 from qiskit.providers.aer.pulse.system_models.hamiltonian_model import HamiltonianModel
 from qiskit.providers.aer.pulse.system_models import duffing_model_generators as model_gen
 from qiskit.providers.aer.pulse.qutip_extra_lite.qobj_generators import get_oper
+from qiskit.providers.models.backendconfiguration import UchannelLO
 
 class TestDuffingModelGenerators(QiskitAerTestCase):
     """Tests for functions in duffing_model_generators.py"""
@@ -55,13 +56,13 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
 
         # check u_channel_lo is correct
         self.assertEqual(system_model.u_channel_lo,
-                         [[{'scale': [1.0, 0.0], 'q' : 1}], [{'scale': [1.0, 0.0], 'q' : 0}]])
+                         [[UchannelLO(1, 1.0+0.0j)], [UchannelLO(0, 1.0+0.0j)]])
 
         # check consistency of system_model.u_channel_lo with cr_idx_dict
         # this should in principle be redundant with the above two checks
         for q_pair, idx in cr_idx_dict.items():
             self.assertEqual(system_model.u_channel_lo[idx],
-                             [{'scale': [1.0, 0.0], 'q' : q_pair[1]}])
+                             [UchannelLO(q_pair[1], 1.0+0.0j)])
 
         # check correct hamiltonian
         ham_model = system_model.hamiltonian
@@ -136,16 +137,16 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
 
         # check u_channel_lo is correct
         self.assertEqual(system_model.u_channel_lo,
-                         [[{'scale': [1.0, 0.0], 'q' : 1}],
-                          [{'scale': [1.0, 0.0], 'q' : 0}],
-                          [{'scale': [1.0, 0.0], 'q' : 2}],
-                          [{'scale': [1.0, 0.0], 'q' : 1}]])
+                         [[UchannelLO(1, 1.0+0.0j)],
+                          [UchannelLO(0, 1.0+0.0j)],
+                          [UchannelLO(2, 1.0+0.0j)],
+                          [UchannelLO(1, 1.0+0.0j)]])
 
         # check consistency of system_model.u_channel_lo with cr_idx_dict
         # this should in principle be redundant with the above two checks
         for q_pair, idx in cr_idx_dict.items():
             self.assertEqual(system_model.u_channel_lo[idx],
-                             [{'scale': [1.0, 0.0], 'q' : q_pair[1]}])
+                             [UchannelLO(q_pair[1], 1.0+0.0j)])
 
         # check correct hamiltonian
         ham_model = system_model.hamiltonian
@@ -234,17 +235,17 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
 
         # check u_channel_lo is correct
         self.assertEqual(system_model.u_channel_lo,
-                         [[{'scale': [1.0, 0.0], 'q' : 1}], [{'scale': [1.0, 0.0], 'q' : 0}],
-                          [{'scale': [1.0, 0.0], 'q' : 2}], [{'scale': [1.0, 0.0], 'q' : 0}],
-                          [{'scale': [1.0, 0.0], 'q' : 3}], [{'scale': [1.0, 0.0], 'q' : 0}],
-                          [{'scale': [1.0, 0.0], 'q' : 2}], [{'scale': [1.0, 0.0], 'q' : 1}],
-                          [{'scale': [1.0, 0.0], 'q' : 3}], [{'scale': [1.0, 0.0], 'q' : 1}]])
+                         [[UchannelLO(1, 1.0+0.0j)], [UchannelLO(0, 1.0+0.0j)],
+                          [UchannelLO(2, 1.0+0.0j)], [UchannelLO(0, 1.0+0.0j)],
+                          [UchannelLO(3, 1.0+0.0j)], [UchannelLO(0, 1.0+0.0j)],
+                          [UchannelLO(2, 1.0+0.0j)], [UchannelLO(1, 1.0+0.0j)],
+                          [UchannelLO(3, 1.0+0.0j)], [UchannelLO(1, 1.0+0.0j)]])
 
         # check consistency of system_model.u_channel_lo with cr_idx_dict
         # this should in principle be redundant with the above two checks
         for q_pair, idx in cr_idx_dict.items():
             self.assertEqual(system_model.u_channel_lo[idx],
-                             [{'scale': [1.0, 0.0], 'q' : q_pair[1]}])
+                             [UchannelLO(q_pair[1], 1.0+0.0j)])
 
         # check correct hamiltonian
         ham_model = system_model.hamiltonian
@@ -409,15 +410,15 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
         """Test _cr_lo_list"""
 
         cr_dict = {(0,1): 0, (1,0) : 1, (3,4) : 2}
-        expected = [[{'scale' : [1.0, 0], 'q' : 1}],
-                    [{'scale' : [1.0, 0], 'q' : 0}],
-                    [{'scale' : [1.0, 0], 'q' : 4}]]
+        expected = [[UchannelLO(1, 1.0+0.0j)],
+                    [UchannelLO(0, 1.0+0.0j)],
+                    [UchannelLO(4, 1.0+0.0j)]]
         self.assertEqual(model_gen._cr_lo_list(cr_dict), expected)
 
         cr_dict = {(0,1): 0, (3,4) : 2, (1,0) : 1}
-        expected = [[{'scale' : [1.0, 0], 'q' : 1}],
-                    [{'scale' : [1.0, 0], 'q' : 0}],
-                    [{'scale' : [1.0, 0], 'q' : 4}]]
+        expected = [[UchannelLO(1, 1.0+0.0j)],
+                    [UchannelLO(0, 1.0+0.0j)],
+                    [UchannelLO(4, 1.0+0.0j)]]
         self.assertEqual(model_gen._cr_lo_list(cr_dict), expected)
 
     def test_single_term_generators(self):

--- a/test/terra/openpulse/test_system_models.py
+++ b/test/terra/openpulse/test_system_models.py
@@ -35,11 +35,8 @@ class BaseTestPulseSystemModel(QiskitAerTestCase):
     def setUp(self):
         self._default_qubit_lo_freq = [4.9, 5.0]
         self._u_channel_lo = []
-        self._u_channel_lo.append([UchannelLO.from_dict(x) for x in [
-                                   {'q': 0, 'scale': 1.0+0.0j}]])
-        self._u_channel_lo.append([UchannelLO.from_dict(x) for x in [
-                                   {'q': 0, 'scale': -1.0+0.0j},
-                                   {'q': 1, 'scale': 1.0+0.0j}]])
+        self._u_channel_lo.append([UchannelLO(0, 1.0+0.0j)])
+        self._u_channel_lo.append([UchannelLO(0, -1.0+0.0j), UchannelLO(1, 1.0+0.0j)])
 
     def _simple_system_model(self, v0=5.0, v1=5.1, j=0.01, r=0.02, alpha0=-0.33, alpha1=-0.33):
         hamiltonian = {}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Made the following changes:
- Further updates to `duffing_model_generators` and corresponding tests to switch over to using `UchannelLO` instead of the dictionary version.
- Added additional test in `test_duffing_model_generators` to call `PulseSystemModel.calculate_channel_frequencies` - this test will now catch any errors resulting from `duffing_model_generators` using an invalid format for specifying u channel los.
- Fixed a bug found in writing the above test: in `duffing_model_generators`, if a coupling strength was `0.0` it would cause an error as it was ultimately being input as `None` when compiling the `PulseSystemModel` object, due to incorrect use of python's `or` function. 
- Modified a couple parts of @mtreinish 's PR to directly construct `UchannelLO` objects (as opposed to using the `from_dict` method.
