### PR TITLE
handle deprecation of pulse simulation in tests

### DIFF
--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -40,7 +40,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         """Test that configuration, defaults, and properties are correclty imported."""
 
         athens_backend = FakeAthens()
-        athens_sim = PulseSimulator.from_backend(athens_backend)
+        with self.assertWarns(DeprecationWarning):
+            athens_sim = PulseSimulator.from_backend(athens_backend)
 
         self.assertEqual(athens_backend.properties(), athens_sim.properties())
         # check that configuration is correctly imported
@@ -79,7 +80,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         """Test that the system model is correctly imported from the backend."""
 
         athens_backend = FakeAthens()
-        athens_sim = PulseSimulator.from_backend(athens_backend)
+        with self.assertWarns(DeprecationWarning):
+            athens_sim = PulseSimulator.from_backend(athens_backend)
 
         # u channel lo
         athens_attr = athens_backend.configuration().u_channel_lo
@@ -97,7 +99,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         """Test setting of options that need to be changed in multiple places."""
 
         athens_backend = FakeAthens()
-        athens_sim = PulseSimulator.from_backend(athens_backend)
+        with self.assertWarns(DeprecationWarning):
+            athens_sim = PulseSimulator.from_backend(athens_backend)
 
         # u channel lo
         set_attr = [[UchannelLO(0, 1.0 + 0.0j)]]
@@ -118,7 +121,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         Results don't matter, just need to check that it runs.
         """
 
-        backend = PulseSimulator.from_backend(FakeAthens())
+        with self.assertWarns(DeprecationWarning):
+            backend = PulseSimulator.from_backend(FakeAthens())
 
         qc = QuantumCircuit(2)
         qc.x(0)
@@ -132,7 +136,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         """Verify error is raised if a parametric pulse makes it into the digest."""
 
         fake_backend = FakeAthens()
-        backend = PulseSimulator.from_backend(fake_backend)
+        with self.assertWarns(DeprecationWarning):
+            backend = PulseSimulator.from_backend(fake_backend)
 
         # reset parametric_pulses option
         backend.set_option('parametric_pulses', fake_backend.configuration().parametric_pulses)
@@ -150,7 +155,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         """Test setting of meas_levels."""
 
         athens_backend = FakeAthens()
-        athens_sim = PulseSimulator.from_backend(athens_backend)
+        with self.assertWarns(DeprecationWarning):
+            athens_sim = PulseSimulator.from_backend(athens_backend)
 
         # test that a warning is thrown when meas_level 0 is attempted to be set
         with warnings.catch_warnings(record=True) as w:
@@ -187,7 +193,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
             armonk_sim = PulseSimulator.from_backend(backend=armonk_backend,
                                                      system_model=system_model)
 
-            self.assertEqual(len(w), 1)
+            self.assertEqual(len(w), 2)
+            self.assertTrue('will be removed in a future release' in str(w[0].message))
             self.assertTrue('inconsistencies' in str(w[-1].message))
 
         # check that system model properties have been imported
@@ -211,7 +218,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
 
             test_sim = PulseSimulator(system_model=system_model)
 
-            self.assertEqual(len(w), 0)
+            self.assertEqual(len(w), 1)
+            self.assertTrue('will be removed in a future release' in str(w[0].message))
 
         # check that system model properties have been imported
         self.assertEqual(test_sim.configuration().dt, system_model.dt)
@@ -226,7 +234,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         system_model.u_channel_lo = [[UchannelLO(0, 1.0 + 0.0j)]]
 
         # first test setting after construction with no hamiltonian
-        test_sim = PulseSimulator()
+        with self.assertWarns(DeprecationWarning):
+            test_sim = PulseSimulator()
 
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
@@ -243,7 +252,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         # next, construct a pulse simulator with a config containing a Hamiltonian and observe
         # warnings
         armonk_backend = FakeArmonk()
-        test_sim = PulseSimulator(configuration=armonk_backend.configuration())
+        with self.assertWarns(DeprecationWarning):
+            test_sim = PulseSimulator(configuration=armonk_backend.configuration())
 
         # add system model and verify warning is raised
         with warnings.catch_warnings(record=True) as w:
@@ -261,7 +271,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
     def test_validation_num_acquires(self):
         """Test that validation fails if 0 or >1 acquire is given in a schedule."""
 
-        test_sim = PulseSimulator.from_backend(FakeArmonk())
+        with self.assertWarns(DeprecationWarning):
+            test_sim = PulseSimulator.from_backend(FakeArmonk())
         test_sim.set_options(
             meas_level=2,
             qubit_lo_freq=test_sim.defaults().qubit_freq_est,
@@ -298,7 +309,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         dt = 2.2222222222222221e-10
         armonk_backend.configuration().dt = dt
 
-        armonk_sim = PulseSimulator.from_backend(armonk_backend)
+        with self.assertWarns(DeprecationWarning):
+            armonk_sim = PulseSimulator.from_backend(armonk_backend)
         armonk_sim.set_options(
             meas_level=2,
             meas_return='single',

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -49,14 +49,16 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         """ Set configuration settings for pulse simulator"""
         super().setUp()
         # Get pulse simulator backend
-        self.backend_sim = PulseSimulator()
+        with self.assertWarns(DeprecationWarning):
+            self.backend_sim = PulseSimulator()
 
         self.X = np.array([[0., 1.], [1., 0.]])
         self.Y = np.array([[0., -1j], [1j, 0.]])
         self.Z = np.array([[1., 0.], [0., -1.]])
 
     def test_circuit_conversion(self):
-        pulse_sim = PulseSimulator.from_backend(FakeArmonk())
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator.from_backend(FakeArmonk())
         qc = QuantumCircuit(1)
         qc.h(0)
         qc.t(0)
@@ -67,7 +69,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                    delta=128)
 
     def test_multiple_circuit_conversion(self):
-        pulse_sim = PulseSimulator.from_backend(FakeArmonk())
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator.from_backend(FakeArmonk())
         qc = QuantumCircuit(1)
         qc.h(0)
         qc.t(0)
@@ -101,7 +104,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         seed = 9000
 
         # set up simulator
-        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -152,7 +156,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         seed = 9000
 
         # set up simulator
-        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -188,7 +193,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         seed = 9000
 
         # set up simulator
-        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -239,7 +245,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         seed = 9000
 
         # set up simulator
-        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -292,8 +299,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         noise_model = {"qubit": {"0": {"Sm": 1.}}}
 
         # set up simulator
-        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r),
-                                   noise_model=noise_model)
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r),
+                                    noise_model=noise_model)
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -329,7 +337,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         y0 = np.array([1.0, 0.0])
         seed = 9000
 
-        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -373,7 +382,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
             # set up simulator
             system_model = self._system_model_1Q(omega_0, r)
-            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+            with self.assertWarns(DeprecationWarning):
+                pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
             pulse_sim.set_options(dt=scale)
             pulse_sim.set_options(
                 meas_level=2,
@@ -435,7 +445,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
             with self.subTest(i=i):
 
                 # set up simulator
-                pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r_vals[i]))
+                with self.assertWarns(DeprecationWarning):
+                    pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r_vals[i]))
                 pulse_sim.set_options(
                     meas_level=2,
                     meas_return='single',
@@ -486,7 +497,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # set up simulator
         system_model = system_model = self._system_model_3d_oscillator(freq, anharm, r)
-        pulse_sim = PulseSimulator(system_model=system_model)
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=system_model)
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -547,7 +559,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
         seed=9000
 
-        pulse_sim = PulseSimulator(system_model=self._system_model_2Q(j))
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=self._system_model_2Q(j))
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -589,7 +602,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
 
         system_model = self._system_model_3Q(j, subsystem_list=subsystem_list)
-        pulse_sim = PulseSimulator(system_model=system_model)
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=system_model)
 
         schedule = self._3Q_constant_sched(total_samples,
                                            u_idx=0,
@@ -683,9 +697,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                         u_channel_lo=u_channel_lo,
                                         subsystem_list=subsystem_list,
                                         dt=dt)
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=np.array([1., 0.]),
-                                   seed=9000)
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=system_model,
+                                       initial_state=np.array([1., 0.]),
+                                       seed=9000)
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -724,9 +739,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         schedule = self._1Q_constant_sched(total_samples, amp=amp)
 
         y0=np.array([1.0, 0.0])
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=9000)
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=system_model,
+                                       initial_state=y0,
+                                       seed=9000)
         pulse_sim.set_options(
             meas_level=1,
             meas_return='single',
@@ -782,7 +798,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         gauss_sigmas = [total_samples / 6, total_samples / 3, total_samples]
 
         # set up pulse simulator
-        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -859,9 +876,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                             MemorySlot(1)) << 3 * total_samples
 
         y0 = np.array([1., 0., 0., 0.])
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=9000)
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=system_model,
+                                    initial_state=y0,
+                                    seed=9000)
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -919,8 +937,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
         # Result of schedule should be the unitary -1j*Z, so check rotation of an X eigenstate
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=np.array([1., 1.]) / np.sqrt(2))
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=system_model,
+                                       initial_state=np.array([1., 1.]) / np.sqrt(2))
         pulse_sim.set_options(
             meas_return='single',
             meas_map=[[0]],
@@ -981,8 +1000,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         y0 = np.array([1., 0])
 
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0)
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=system_model,
+                                       initial_state=y0)
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -1052,8 +1072,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
         y0 = np.array([1., 0.])
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0)
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=system_model,
+                                       initial_state=y0)
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -1088,8 +1109,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
         y0 = np.array([1., 1.]) / np.sqrt(2)
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0)
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=system_model,
+                                       initial_state=y0)
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',
@@ -1119,7 +1141,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         total_samples = 100
 
         # set up simulator
-        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
 
         # set up schedule with ShiftFrequency
         drive_pulse = Waveform(1. * np.ones(total_samples))
@@ -1162,7 +1185,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         seed = 9000
 
         # set up simulator
-        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
         frequencies = np.array([0.5, 1.0, 1.5]) * omega_d
         pulse_sim.set_options(
             shots=128
@@ -1221,9 +1245,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                             MemorySlot(1)) << 3 * total_samples
 
         y0 = np.array([1., 1., 0., 0., 0., 0., 0., 0., 0.]) / np.sqrt(2)
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=50)
+        with self.assertWarns(DeprecationWarning):
+            pulse_sim = PulseSimulator(system_model=system_model,
+                                       initial_state=y0,
+                                       seed=50)
         pulse_sim.set_options(
             meas_level=2,
             meas_return='single',


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add `with self.assertWarns(DeprecationWarning):` before construct of `PulseSimulator` to pass all the tests

### Details and comments


